### PR TITLE
Fix sly/forced deal property name handling

### DIFF
--- a/game.py
+++ b/game.py
@@ -297,9 +297,10 @@ class Game:
         target_player = self._get_player_by_name(target_player_name)
         if target_player is None:
             raise ValueError(f"Target player {target_player_name} not found for action {action}.")
-        target_player.remove_card_from_properties(action.forced_or_sly_deal_target_property_name)
-        player.add_card_to_properties(action.forced_or_sly_deal_target_property_name)
-        print(f"{player.name} stole property {action.forced_or_sly_deal_target_property_name} from {target_player_name} with a sly deal.")
+        stolen_card = target_player.get_card_from_properties(action.forced_or_sly_deal_target_property_name)
+        target_player.remove_card_from_properties(stolen_card)
+        player.add_card_to_properties(stolen_card)
+        print(f"{player.name} stole property {stolen_card.name} from {target_player_name} with a sly deal.")
         
     
     def _execute_forced_deal(self, action: Action):
@@ -308,11 +309,13 @@ class Game:
         target_player = self._get_player_by_name(target_player_name)
         if target_player is None:
             raise ValueError(f"Target player {target_player_name} not found for action {action}.")
-        player.remove_card_from_properties(action.forced_deal_source_property_name)
-        target_player.add_card_to_properties(action.forced_deal_source_property_name)
-        player.add_card_to_properties(action.forced_or_sly_deal_target_property_name)
-        target_player.remove_card_from_properties(action.forced_or_sly_deal_target_property_name)
-        print(f"{player.name} forced deal {action.forced_deal_source_property_name} to {target_player_name} and received {action.forced_or_sly_deal_target_property_name}.")
+        source_card = player.get_card_from_properties(action.forced_deal_source_property_name)
+        target_card = target_player.get_card_from_properties(action.forced_or_sly_deal_target_property_name)
+        player.remove_card_from_properties(source_card)
+        target_player.add_card_to_properties(source_card)
+        target_player.remove_card_from_properties(target_card)
+        player.add_card_to_properties(target_card)
+        print(f"{player.name} forced deal {source_card.name} to {target_player_name} and received {target_card.name}.")
         
         
         

--- a/player.py
+++ b/player.py
@@ -102,6 +102,14 @@ class Player(ABC): # Inherit from ABC
                 return True
         return False
 
+    def get_card_from_properties(self, card_name: str):
+        """Retrieve a property card object given its name."""
+        for prop_set in self.property_sets.values():
+            for card in prop_set.cards:
+                if card.name == card_name:
+                    return card
+        raise ValueError(f"Error: Card {card_name} not found in properties.")
+
     def get_bank_value(self) -> int:
         """Calculates the total monetary value of cards in the bank."""
         # Assumes cards in bank have a 'value' attribute


### PR DESCRIPTION
## Summary
- add Player.get_card_from_properties to look up property cards by name
- fix `_execute_sly_deal` and `_execute_forced_deal` to use card objects

## Testing
- `python -m py_compile player.py game.py action.py deck.py rules_engine.py action_executor.py`

------
https://chatgpt.com/codex/tasks/task_e_683fa13b9d488320abd785404f3864bf