### PR TITLE
Migrate property references to ActionPropertyInfo

### DIFF
--- a/action.py
+++ b/action.py
@@ -1,6 +1,6 @@
-from typing import List, Optional, Tuple
+from __future__ import annotations
+from typing import List, Optional
 from card import BuildingCard, Card, PropertyCard, WildPropertyCard, PropertyColor
-from player import Player 
 from dataclasses import dataclass
 from enum import Enum, auto
 
@@ -15,18 +15,27 @@ class ActionType(Enum):
 
 
 @dataclass
+class ActionPropertyInfo:
+    name: str
+    prop_color: PropertyColor
+
+    def __repr__(self) -> str:
+        return f"ActionPropertyInfo(name='{self.name}', prop_color={self.prop_color.name})"
+
+
+@dataclass
 class Action:
 
     def __init__(self,
         action_type: ActionType,
-        source_player: Player, 
+        source_player: 'Player',
         card: Optional[Card] = None, # Card object being played
         target_player_names: Optional[List[str]] = None, # List of Player names, if applicable
         target_property_set: Optional[PropertyColor] = None,
         rent_color: Optional[PropertyColor] = None,
         double_the_rent_count: Optional[int] = 0,
-        forced_deal_source_property_info: Optional[Tuple[str, PropertyColor]] = None,
-        forced_or_sly_deal_target_property_info: Optional[Tuple[str, PropertyColor]] = None):
+        forced_deal_source_property_info: Optional[ActionPropertyInfo] = None,
+        forced_or_sly_deal_target_property_info: Optional[ActionPropertyInfo] = None):
         """Represents a game action taken by a player."""
         self.action_type = action_type
         self.source_player = source_player
@@ -74,5 +83,5 @@ class Action:
             components.append(f"forced_deal_source_property_info={self.forced_deal_source_property_info}")
         if self.forced_or_sly_deal_target_property_info:
             components.append(f"forced_or_sly_deal_target_property_info={self.forced_or_sly_deal_target_property_info}")
-    
+
         return f"<{', '.join(components)}>"

--- a/player.py
+++ b/player.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, List, Dict, Optional
 
 from card import Card, MoneyCard, PropertySet, PropertyColor, PropertyCard, WildPropertyCard, CardType
+from action import ActionPropertyInfo
 
 class Player(ABC): # Inherit from ABC
     """Abstract Base Class for a player in the game."""
@@ -102,11 +103,11 @@ class Player(ABC): # Inherit from ABC
                 return True
         return False
 
-    def get_card_from_properties(self, card_name: str, color: PropertyColor):
-        """Retrieve a property card object given its name."""
-        prop_set = self.property_sets[color]
+    def get_card_from_properties(self, info: 'ActionPropertyInfo'):
+        """Retrieve a property card object given its name and color."""
+        prop_set = self.property_sets[info.prop_color]
         for card in prop_set.cards:
-            if card.name == card_name:
+            if card.name == info.name:
                 return card
         return None
 

--- a/rules_engine.py
+++ b/rules_engine.py
@@ -1,5 +1,5 @@
 from typing import Any, List, Optional, Tuple
-from action import Action, ActionType
+from action import Action, ActionType, ActionPropertyInfo
 from card import CardType, PropertyColor, PropertyCard, RentCard, BuildingCard, ActionCard, Card, WildPropertyCard # etc.
 from player import Player
 from deck_config import ACTIONS_PER_TURN
@@ -289,12 +289,12 @@ class RulesEngine:
         if action.target_property_set is not None:
             print(f"Validation Error: Sly Deal should not specify target property set. {action}")
             return False
-        if not target_players[0].has_card(action.forced_or_sly_deal_target_property_name): # TODO fix 
+        if not target_players[0].has_card(action.forced_or_sly_deal_target_property_info.name):
             print(f"Validation Error: Sly Deal target property not found in target player. {action}")
-            return False 
+            return False
         target_property_set = None
         for color, prop_set in target_players[0].get_property_sets().items():
-            if prop_set.has_card(action.forced_or_sly_deal_target_property_name):
+            if prop_set.has_card(action.forced_or_sly_deal_target_property_info.name):
                 target_property_set = prop_set
                 break
         if target_property_set is None:
@@ -316,12 +316,12 @@ class RulesEngine:
         if action.target_property_set is not None:
             print(f"Validation Error: Forced Deal should not specify target property set. {action}")
             return False
-        print(f"{action.forced_or_sly_deal_target_property_name}")
-        target_property_card = target_players[0].get_card_from_properties(*action.forced_or_sly_deal_target_property_name)
+        print(f"{action.forced_or_sly_deal_target_property_info}")
+        target_property_card = target_players[0].get_card_from_properties(action.forced_or_sly_deal_target_property_info)
         if target_property_card is None:
             print(f"Validation Error: Forced Deal target property not found in target player. {action}")
             return False
-        source_property_card = player.get_card_from_properties(*action.forced_deal_source_property_name)
+        source_property_card = player.get_card_from_properties(action.forced_deal_source_property_info)
         if source_property_card is None:
             print(f"Validation Error: Forced Deal source property not found in source player. {action}")
             return False


### PR DESCRIPTION
## Summary
- add `ActionPropertyInfo` dataclass
- update action object to use new info object
- update player, rules engine and game logic for new type
- adjust random action generation to work with `ActionPropertyInfo`

## Testing
- `python -m py_compile *.py`
- `python game.py`

------
https://chatgpt.com/codex/tasks/task_e_684864bee8e483209a290f85d2ebbc86