### PR TITLE
Fix prompts for payment and player state display

### DIFF
--- a/prompts/game_state_display.j2
+++ b/prompts/game_state_display.j2
@@ -2,7 +2,7 @@
 {{ card.items() | map('join', ': ') | join(', ') }}
 {%- endmacro %}
 
-{% macro display_game_state(game_state, actions_per_turn, current_player) %}
+{% macro display_game_state(game_state, actions_per_turn, perspective_player) %}
 Game state:
 - Current player Turn: {{ game_state.current_player_name }}
 - Players: {{ game_state.players | map(attribute='name') | list }}
@@ -11,24 +11,24 @@ Game state:
 
 Your current game state:
 - Hand:
-{% if current_player.hand %}
-{% for card in current_player.hand %}
+{% if perspective_player.hand %}
+{% for card in perspective_player.hand %}
 - - {{ render_card(card.to_json()) }}
 {% endfor %}
 {% else %}
   None.
 {% endif %}
-- Bank (Total value: {{ current_player.get_bank_value() }}):
-{% if current_player.bank %}
-{% for card in current_player.bank %}
+- Bank (Total value: {{ perspective_player.get_bank_value() }}):
+{% if perspective_player.bank %}
+{% for card in perspective_player.bank %}
 - - {{ render_card(card.to_json()) }}
 {% endfor %}
 {% else %}
   None.
 {% endif %}
 - Property Sets:
-{% if current_player.property_sets %}
-  {% for color, prop_set in current_player.property_sets.items() %}
+{% if perspective_player.property_sets %}
+  {% for color, prop_set in perspective_player.property_sets.items() %}
   - {{ color.name}}:
     Cards:
     {% if prop_set.cards %}
@@ -48,7 +48,7 @@ Your current game state:
 
 Other players:
 {% for player in game_state.players %}
-  {% if player.name != game_state.current_player_name %}
+  {% if player.name != perspective_player.name %}
 - {{ player.name }}:
   - Bank (Total value: {{ player.bank_value }}):
     {% if player.banked_cards %}

--- a/prompts/provide_payment_prompt.j2
+++ b/prompts/provide_payment_prompt.j2
@@ -1,5 +1,5 @@
 {% from 'game_state_display.j2' import display_game_state %}
-You are AI player ({{ game_state.current_player_name }}) in a Monopoly Deal game and need to pay {{ amount }}M for the following reason: {{ reason }}
+You are AI player ({{ player.name }}) in a Monopoly Deal game and need to pay {{ amount }}M for the following reason: {{ reason }}
 
 {{ display_game_state(game_state, actions_per_turn, player) }}
 


### PR DESCRIPTION
## Summary
- fix target player name in provide_payment_prompt
- update game_state_display macro to show the perspective player's info and skip them in the other players list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861e3db9f108320b0ef2225c34fa4f7