### PR TITLE
Implement feedback for tournament concurrency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-dotenv
 requests
 Jinja2
 tenacity
+trio


### PR DESCRIPTION
## Summary
- add customizable batch size for running matches
- raise an error if a game finishes without a winner

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a9031176883209210d8eb81eb1de4