### PR TITLE
Fix wild card color when moving property

### DIFF
--- a/game.py
+++ b/game.py
@@ -238,7 +238,6 @@ class Game:
         target_property_set = action.target_property_set
         
         player.remove_card_from_properties(card)
-        # TODO: need to change the current color of wild property cards 
         player.add_card_to_properties(card, target_property_set)
 
         self.add_to_game_history(f"{player.name} moved property {card.name} to {target_property_set}")

--- a/player.py
+++ b/player.py
@@ -63,7 +63,7 @@ class Player(ABC): # Inherit from ABC
         except ValueError:
             logger.error(f"Error: Card {card} not found in bank.") # Or raise a custom exception
 
-    def add_card_to_properties(self, card, color = None):
+    def add_card_to_properties(self, card, color=None):
         if color is None:
             if isinstance(card, WildPropertyCard):
                 color = card.current_color
@@ -71,6 +71,9 @@ class Player(ABC): # Inherit from ABC
                 color = card.set_color
             else:
                 raise ValueError(f"add_card_to_properties: Error: color is None for card {card}")
+        elif isinstance(card, WildPropertyCard):
+            card.current_color = color
+
         if color not in self.property_sets:
             self.property_sets[color] = PropertySet(card)
         else:


### PR DESCRIPTION
## Summary
- update `add_card_to_properties` to set `current_color` for wild cards when a color is provided
- remove color change logic from `_execute_move_property`

## Testing
- `python -m py_compile game.py card.py player.py rules_engine.py action.py deck.py`


------
https://chatgpt.com/codex/tasks/task_e_686ff98ee2608320a7fe537db8208cab