### PR TITLE
Refactor /game_data response and display

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
     <div class="container">
+        <div id="action-display" class="action-display"></div>
         <h1>Game State</h1>
         <div id="game-board" class="game-board">
             <!-- Player sections will be dynamically generated here -->

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -16,8 +16,14 @@ document.addEventListener('DOMContentLoaded', () => {
     fetch('/game_data')
         .then(response => response.json())
         .then(data => {
+            const gameState = data.game_state;
+            const actionDiv = document.getElementById('action-display');
+            if (actionDiv && data.action) {
+                actionDiv.textContent = data.action;
+            }
+
             const gameBoard = document.getElementById('game-board');
-            data.players.forEach(player => {
+            gameState.players.forEach(player => {
                 const playerSection = document.createElement('div');
                 playerSection.className = 'player-section';
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -4,6 +4,13 @@ body {
     padding: 20px;
 }
 
+.action-display {
+    font-size: 1.5em;
+    font-weight: bold;
+    margin-bottom: 20px;
+    text-align: center;
+}
+
 .container {
     max-width: 1200px;
     margin: 0 auto;

--- a/server.py
+++ b/server.py
@@ -27,8 +27,15 @@ def game_data():
     result = "logs/2025-07-09_20-46-24_anthropic_claude-4-sonnet-20250522_openai_o3_game/result.json"
     with open(result, "r") as f:
         data = json.load(f)
-    
-    return jsonify(data['game_state'])
+
+    action = ""
+    if isinstance(data.get('game_history'), list) and data['game_history']:
+        action = data['game_history'][-1]
+
+    return jsonify({
+        "action": action,
+        "game_state": data.get('game_state', {})
+    })
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- include latest action in `/game_data` endpoint
- display action prominently above the game board
- adjust JS to handle new API shape
- add basic styling for the action text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d7251e0a883209e204ba4cd142f21