### PR TITLE
Implement periodic game state updates

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -12,7 +12,7 @@ const PROPERTY_COLORS = {
 };
 const WILD_PROPERTY_COLOR = '#efefef';
 
-document.addEventListener('DOMContentLoaded', () => {
+function loadGameData() {
     fetch('/game_data')
         .then(response => response.json())
         .then(data => {
@@ -23,6 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             const gameBoard = document.getElementById('game-board');
+            gameBoard.innerHTML = '';
             gameState.players.forEach(player => {
                 const playerSection = document.createElement('div');
                 playerSection.className = 'player-section';
@@ -75,6 +76,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 gameBoard.appendChild(playerSection);
             });
         });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadGameData();
+    setInterval(loadGameData, 2000);
 });
 
 function createCardArea(title, cards, cardClassFunc) {

--- a/server.py
+++ b/server.py
@@ -6,10 +6,56 @@ Run with `python server.py` (Python 3.9+) and visit http://localhost:5000
 """
 from flask import Flask, jsonify
 import json
-import os 
+import os
+import glob
+import threading
+import time
+import re
 
 # Tell Flask where the frontend lives and expose it at the root URL ("/")
 app = Flask(__name__, static_folder="frontend", static_url_path="")
+
+# Directory containing sequential game state JSON files.
+# Can be overridden with the LOG_DIR environment variable.
+LOG_DIR = os.environ.get("LOG_DIR", "logs/2025-07-20_18-21-20_Randy_Bob_game")
+
+# Shared dictionary that always holds the latest loaded data.
+latest_data = {}
+
+
+def _get_json_files():
+    """Return list of game data files sorted by turn then action number."""
+    pattern = os.path.join(LOG_DIR, "turn-*_actions-*.json")
+    files = glob.glob(pattern)
+
+    def sort_key(path):
+        name = os.path.basename(path)
+        m = re.match(r"turn-(\d+)_actions-(\d+)\.json", name)
+        if m:
+            return int(m.group(1)), int(m.group(2))
+        return float("inf"), float("inf")
+
+    return sorted(files, key=sort_key)
+
+
+def update_data_loop():
+    """Background loop to load a new file every two seconds."""
+    files = _get_json_files()
+    idx = 0
+    while True:
+        if idx < len(files):
+            try:
+                with open(files[idx], "r") as f:
+                    data = json.load(f)
+                latest_data.clear()
+                latest_data.update(data)
+                idx += 1
+            except Exception as exc:
+                print(f"Failed reading {files[idx]}: {exc}")
+        time.sleep(2)
+
+
+threading.Thread(target=update_data_loop, daemon=True).start()
 
 
 @app.route("/")
@@ -20,22 +66,14 @@ def index():
 
 @app.route("/game_data")
 def game_data():
-    """Return a very small, hard‑coded snapshot of game state for demo purposes.
-    Replace or extend this with your real game engine / database call.
-    """
-    print(os.getcwd())
-    result = "logs/2025-07-09_20-46-24_anthropic_claude-4-sonnet-20250522_openai_o3_game/result.json"
-    with open(result, "r") as f:
-        data = json.load(f)
+    """Return the most recently loaded game data."""
+    data = latest_data or {}
 
     action = ""
-    if isinstance(data.get('game_history'), list) and data['game_history']:
-        action = data['game_history'][-1]
+    if isinstance(data.get("game_history"), list) and data["game_history"]:
+        action = data["game_history"][-1]
 
-    return jsonify({
-        "action": action,
-        "game_state": data.get('game_state', {})
-    })
+    return jsonify({"action": action, "game_state": data.get("game_state", {})})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- load game state JSON files sequentially in a background thread
- poll the server from the frontend every two seconds

## Testing
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_687d9750b54883209bae827463b1f8cd