### PR TITLE
Add CLI arguments for game and tournaments

### DIFF
--- a/dealbench/game.py
+++ b/dealbench/game.py
@@ -639,22 +639,27 @@ def setup_logging(log_file_folder: str):
         format="%(asctime)s - %(name)s - %(threadName)s - %(levelname)s - %(message)s"
     ) 
 
-# Example Usage (Conceptual - requires other classes and deck_utils)
 if __name__ == "__main__":
-    players = [
-        # TestPlayer(name="Randy"),
-        # TestPlayer(name="Bob"),
-        # meta_maverick,
-        # gpt_4_1_nano,
-        # deepseek_r1,
-        # qwen3_235b,
-        claude_4_sonnet,
-        openai_o4_mini,
-        # openai_o3,
-        # gemini_2_5_pro
-        # kimi_k2
-    ]
-    assert len(players) == len(set([player.name for player in players])), "Player names should be unique!"
+    import argparse
+    from dealbench.llm import LLMPlayer
+
+    parser = argparse.ArgumentParser(description="Run a single DealBench game")
+    parser.add_argument(
+        "--model",
+        nargs="+",
+        dest="models",
+        required=True,
+        help="Space separated list of model names. Use 'random' for a TestPlayer.",
+    )
+    args = parser.parse_args()
+
+    players = []
+    for idx, model in enumerate(args.models, start=1):
+        if model.lower() == "random":
+            players.append(TestPlayer(name=f"random_{idx}"))
+        else:
+            players.append(LLMPlayer(model_name=model))
+
     game = Game(players)
     setup_logging(game.game_identifier)
     game.run_game()

--- a/dealbench/tournament.py
+++ b/dealbench/tournament.py
@@ -130,22 +130,25 @@ def run_tournaments(players: List[Player], num_runs: int = 1, num_concurrent_gam
 
 
 if __name__ == "__main__":
-    players = [
-        # TestPlayer(name="test_player_1"),
-        # TestPlayer(name="test_player_2"),
-        # TestPlayer(name="test_player_3"),
-        # TestPlayer(name="test_player_4"),
-        # TestPlayer(name="test_player_5"),
-        # TestPlayer(name="test_player_6"),
-        # TestPlayer(name="test_player_7"),
-        # TestPlayer(name="test_player_8"),
-        # TestPlayer(name="test_player_9"),
-        # TestPlayer(name="test_player_10"),
-        TestPlayer(name="Randy"),
-        openai_o3,
-        claude_4_sonnet,
-        gemini_2_5_pro,
-        openai_o4_mini
-    ]
+    import argparse
+    from dealbench.llm import LLMPlayer
 
-    run_tournaments(players)
+    parser = argparse.ArgumentParser(description="Run a DealBench tournament")
+    parser.add_argument(
+        "--model",
+        nargs="+",
+        dest="models",
+        required=True,
+        help="Space separated list of model names. Use 'random' for a TestPlayer.",
+    )
+    parser.add_argument("--concurrency", type=int, default=6, help="Number of concurrent games")
+    args = parser.parse_args()
+
+    players = []
+    for idx, model in enumerate(args.models, start=1):
+        if model.lower() == "random":
+            players.append(TestPlayer(name=f"random_{idx}"))
+        else:
+            players.append(LLMPlayer(model_name=model))
+
+    run_tournaments(players, num_concurrent_games=args.concurrency)


### PR DESCRIPTION
## Summary
- allow passing model names to game and tournament via `--model`
- random players are named using their index
- revert frontend server back to original behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688a32aa6a5483209af5009e376ed4f7