### PR TITLE
Create simple static game viewer

### DIFF
--- a/frontend/simple/game_data_example.js
+++ b/frontend/simple/game_data_example.js
@@ -1,0 +1,50 @@
+const gameData = {
+  game_state: {
+    current_player_name: "Player A",
+    players: [
+      {
+        name: "Player A",
+        banked_cards: [
+          {name: "$2M", value: 2, type: "MONEY"},
+          {name: "$3M", value: 3, type: "MONEY"}
+        ],
+        property_sets: {
+          RED: {
+            set_color: "RED",
+            cards: [
+              {name:"Kentucky Ave", value: 3, type:"PROPERTY", set_color:"RED"},
+              {name:"Indiana Ave", value: 3, type:"PROPERTY", set_color:"RED"}
+            ],
+            number_for_full_set: 3,
+            is_full_set: false
+          },
+          GREEN: {
+            set_color:"GREEN",
+            cards:[
+              {name:"Pacific Ave", value:4, type:"PROPERTY", set_color:"GREEN"},
+              {name:"North Carolina Ave", value:4, type:"PROPERTY", set_color:"GREEN"},
+              {name:"Pennsylvania Ave", value:4, type:"PROPERTY", set_color:"GREEN"}
+            ],
+            number_for_full_set: 3,
+            is_full_set: true
+          }
+        },
+        hand_cards:[
+          {name:"just say no", type:"ACTION_JUST_SAY_NO", value:4},
+          {name:"sunset blvd", type:"PROPERTY", set_color:"ORANGE", value:2},
+          {name:"$2M", type:"MONEY", value:2}
+        ]
+      },
+      {
+        name:"Player B",
+        banked_cards:[{name:"$1M", value:1, type:"MONEY"}],
+        property_sets:{},
+        hand_cards:[
+          {name:"deal breaker", type:"ACTION", value:5},
+          {name:"$3M", type:"MONEY", value:3}
+        ]
+      }
+    ]
+  },
+  winner: "Player A"
+};

--- a/frontend/simple/simple.css
+++ b/frontend/simple/simple.css
@@ -1,0 +1,34 @@
+body { font-family: Arial, sans-serif; padding: 20px; }
+.player { border: 1px solid #ccc; padding: 10px; margin-bottom: 15px; }
+.player h2 { margin: 0 0 10px 0; }
+
+/* Winner modal styling */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 20px 40px;
+  border-radius: 10px;
+  font-size: 2em;
+  font-weight: bold;
+  text-align: center;
+}
+
+.confetti {
+  position: fixed;
+  width: 8px;
+  height: 8px;
+  pointer-events: none;
+  z-index: 1100;
+}

--- a/frontend/simple/simple.html
+++ b/frontend/simple/simple.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Deal Bench Game Viewer</title>
+<link rel="stylesheet" href="simple.css">
+</head>
+<body>
+<h1>Game State</h1>
+<div id="game-board"></div>
+<div id="winner-modal" class="modal">
+  <div class="modal-content">
+    <span id="winner-message"></span>
+  </div>
+</div>
+<script src="game_data_example.js"></script>
+<script src="simple.js"></script>
+</body>
+</html>

--- a/frontend/simple/simple.js
+++ b/frontend/simple/simple.js
@@ -1,0 +1,110 @@
+function colorEmoji(color) {
+  const map = {
+    RED: '🟥',
+    GREEN: '🟩',
+    BLUE: '🟦',
+    DARK_BLUE: '🟦',
+    LIGHT_BLUE: '🟦',
+    PINK: '🟪',
+    ORANGE: '🟧',
+    YELLOW: '🟨',
+    BROWN: '🟫',
+    RAILROAD: '⬜',
+    UTILITY: '⬛'
+  };
+  return map[color] || '';
+}
+
+function renderCardText(card) {
+  if (card.type && card.type.includes('MONEY')) {
+    return `💰$${card.value}M`;
+  }
+  if (card.type && card.type.includes('PROPERTY')) {
+    const emoji = colorEmoji(card.set_color || card.current_color);
+    return `${emoji}`;
+  }
+  if (card.type && card.type.includes('ACTION')) {
+    return `🎴${card.name}`;
+  }
+  return card.name;
+}
+
+function renderGame(gameState) {
+  const board = document.getElementById('game-board');
+  board.innerHTML = '';
+
+  gameState.players.forEach(player => {
+    const section = document.createElement('div');
+    section.className = 'player';
+
+    const title = document.createElement('h2');
+    if (player.name === gameState.current_player_name) {
+      title.textContent = `[${player.name}'s Turn]`;
+    } else {
+      title.textContent = player.name;
+    }
+    section.appendChild(title);
+
+    const bankLine = document.createElement('div');
+    const bankCards = player.banked_cards.map(renderCardText).join(', ');
+    bankLine.textContent = `Bank 🏦: ${bankCards}`;
+    section.appendChild(bankLine);
+
+    const propLine = document.createElement('div');
+    const propSets = Object.values(player.property_sets || {}).map(set => {
+      const squares = colorEmoji(set.set_color).repeat(set.cards.length);
+      const status = set.is_full_set ? ' - Complete' : ` (${set.cards.length}/${set.number_for_full_set} ${set.set_color})`;
+      return `${squares}${status}`;
+    }).join(' | ');
+    propLine.textContent = `Properties 🏠: ${propSets}`;
+    section.appendChild(propLine);
+
+    const handLine = document.createElement('div');
+    const handCards = player.hand_cards.map(renderCardText).join(' ');
+    handLine.textContent = `Hand 🃏: ${handCards}`;
+    section.appendChild(handLine);
+
+    board.appendChild(section);
+  });
+}
+
+function launchConfetti() {
+  const colors = ['#bb0000', '#00bb00', '#0000bb', '#bbbb00', '#bb00bb', '#00bbbb'];
+  for (let i = 0; i < 100; i++) {
+    const conf = document.createElement('div');
+    conf.className = 'confetti';
+    conf.style.backgroundColor = colors[Math.floor(Math.random() * colors.length)];
+    conf.style.left = Math.random() * 100 + '%';
+    conf.style.top = '-10px';
+    conf.style.opacity = '1';
+    document.body.appendChild(conf);
+    const fall = 3000 + Math.random() * 1000;
+    conf.animate([
+      { transform: `rotate(${Math.random() * 360}deg)`, top: '-10px', opacity: 1 },
+      { transform: `rotate(${Math.random() * 360}deg)`, top: '110%', opacity: 0 }
+    ], { duration: fall });
+    setTimeout(() => conf.remove(), fall);
+  }
+}
+
+function announceWinner(winner) {
+  const modal = document.getElementById('winner-modal');
+  const message = document.getElementById('winner-message');
+  if (modal && message) {
+    message.textContent = `${winner} wins!`;
+    modal.style.display = 'flex';
+    modal.addEventListener('click', () => {
+      modal.style.display = 'none';
+    }, { once: true });
+    launchConfetti();
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (typeof gameData !== 'undefined' && gameData.game_state) {
+    renderGame(gameData.game_state);
+    if (gameData.winner) {
+      announceWinner(gameData.winner);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add a `frontend/simple/` folder with plain HTML, CSS and JS files
- sample game data is included so the page can render without a server
- small improvements to the simple viewer
- add confetti winner popup when `winner` is true

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cd12236988320a6f7f0666d57accf