### PR TITLE
Enhance replay viewer with reasoning display

### DIFF
--- a/frontend/simple/simple.css
+++ b/frontend/simple/simple.css
@@ -32,3 +32,13 @@ body { font-family: Arial, sans-serif; padding: 20px; }
   pointer-events: none;
   z-index: 1100;
 }
+
+.reasoning {
+  margin-top: 5px;
+  font-style: italic;
+}
+
+.action {
+  margin-top: 5px;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- augment player sections with streaming reasoning/action text
- style reasoning and action sections
- load game data sequentially so reasoning displays before actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cdc376c5883209528ca49ae0651d9