### PR TITLE
Add actions played info in simple frontend

### DIFF
--- a/frontend/simple/simple.js
+++ b/frontend/simple/simple.js
@@ -37,6 +37,8 @@ function renderGame(gameState) {
   const board = document.getElementById('game-board');
   board.innerHTML = '';
 
+  const actionsPlayed = gameState.actions_played_in_current_turn || 0;
+
   gameState.players.forEach(player => {
     const section = document.createElement('div');
     section.className = 'player';
@@ -63,6 +65,10 @@ function renderGame(gameState) {
     }).join(' | ');
     propLine.textContent = `Properties 🏠: ${propSets}`;
     section.appendChild(propLine);
+
+    const actionsLine = document.createElement('div');
+    actionsLine.textContent = `Actions played this turn: ${actionsPlayed}`;
+    section.appendChild(actionsLine);
 
     const handLine = document.createElement('div');
     const handCards = player.hand_cards.map(renderCardText).join(' ');


### PR DESCRIPTION
## Summary
- show `Actions played this turn` for each player in the simple frontend

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688ce17c0d2083209f146fcc73a1f3a5