### PR TITLE
Align server updates with frontend polling

### DIFF
--- a/frontend/simple/simple.js
+++ b/frontend/simple/simple.js
@@ -127,18 +127,24 @@ function announceWinner(winner) {
   }
 }
 
-function typeText(el, text, cb) {
+function typeText(el, text) {
   const speed = 5; // ms per character
   let idx = 0;
-  function type() {
-    if (idx < text.length) {
-      el.textContent += text.charAt(idx++);
-      setTimeout(type, speed);
-    } else if (cb) {
-      cb();
+  return new Promise(resolve => {
+    function type() {
+      if (idx < text.length) {
+        el.textContent += text.charAt(idx++);
+        setTimeout(type, speed);
+      } else {
+        resolve();
+      }
     }
-  }
-  type();
+    type();
+  });
+}
+
+function delay(ms) {
+  return new Promise(res => setTimeout(res, ms));
 }
 
 async function loadGameData() {
@@ -154,7 +160,7 @@ async function loadGameData() {
 
     const playerName = data.game_state?.current_player_name;
     const reasoning = data.reasoning || '';
-    const action = "Action: " + data.action || '';
+    const action = data.action ? `Action: ${data.action}` : '';
     if (playerName) {
       const section = document.getElementById(playerId(playerName));
       if (section) {
@@ -163,15 +169,15 @@ async function loadGameData() {
         if (reasoningEl && actionEl) {
           reasoningEl.textContent = 'Reasoning: ';
           actionEl.textContent = '';
-          typeText(reasoningEl, reasoning, () => {
-            actionEl.textContent = action;
-            setTimeout(loadGameData, 2000);
-          });
-          return;
+          await typeText(reasoningEl, reasoning);
+          actionEl.textContent = action;
+          await delay(2000);
+          return loadGameData();
         }
       }
     }
-    setTimeout(loadGameData, 2000);
+    await delay(2000);
+    return loadGameData();
   } catch (err) {
     if (typeof gameData !== 'undefined' && gameData.game_state) {
       renderGame(gameData.game_state);
@@ -179,7 +185,8 @@ async function loadGameData() {
         announceWinner(gameData.winner);
       }
     }
-    setTimeout(loadGameData, 2000);
+    await delay(2000);
+    return loadGameData();
   }
 }
 


### PR DESCRIPTION
## Summary
- simplify the log loader in `frontend_game_replay_server.py`
- load the next log entry only when `/game_data` is requested
- wait for `typeText` to finish then poll again after 2 seconds

## Testing
- `python -m py_compile frontend_game_replay_server.py`
- `node -c frontend/simple/simple.js`


------
https://chatgpt.com/codex/tasks/task_e_688cea9995308320a6a310bfb3d3a10f