### PR TITLE
feat: enable mobile leaderboard scroll

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -20,8 +20,8 @@
     .stat{background:#fff;border-radius:8px;padding:1.5rem 2rem;box-shadow:0 2px 6px rgba(0,0,0,.05);text-align:center;min-width:140px;}
     .stat .value{font-size:2rem;font-weight:700;}
     .section-title{font-size:1.75rem;font-weight:700;text-align:center;margin:3rem 0 1.5rem;}
-    table{width:100%;border-collapse:collapse;margin-bottom:4rem;}
-    th,td{padding:.75rem;border-bottom:1px solid #e5e5e5;text-align:center;font-size:.95rem;word-break:break-word;}
+    table{width:100%;min-width:600px;border-collapse:collapse;margin-bottom:4rem;}
+    th,td{padding:.75rem;border-bottom:1px solid #e5e5e5;text-align:center;font-size:.95rem;white-space:nowrap;}
     th{background:#f3f3f3;font-weight:600;}
     tbody tr:hover{background:#f9f9f9;}
     .table-wrap{max-width:720px;width:100%;margin:0 auto;padding:0 1rem;overflow-x:auto;}


### PR DESCRIPTION
## Summary
- ensure leaderboard can scroll horizontally on small screens
- prevent cell text wrapping in leaderboard table

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fa9ea8ff88320befc398a33d13b47